### PR TITLE
Add period and dimension values to id

### DIFF
--- a/backdrop/collector/ga.py
+++ b/backdrop/collector/ga.py
@@ -1,3 +1,4 @@
+import base64
 from datetime import timedelta, datetime
 import json
 import logging
@@ -58,16 +59,24 @@ def send_data(data, config):
     response.raise_for_status()
 
 
-def data_id(data_type, timestamp):
-    return "%s_%s" % (data_type, to_utc(timestamp).strftime("%Y%m%d%H%M%S"))
+def data_id(data_type, timestamp, period, dimension_values):
+    return base64.urlsafe_b64encode("_".join(
+        [data_type, to_utc(timestamp).strftime("%Y%m%d%H%M%S"), period] + dimension_values
+    ))
 
 
 def build_document(item, data_type, start_date, end_date):
+    if data_type is None:
+        raise ValueError("Must provide a data type")
+    period = "week"
     base_properties = {
-        "_id": data_id(data_type, to_datetime(start_date)),
+        "_id": data_id(
+            data_type, to_datetime(start_date), period,
+            item.get("dimensions", {}).values()
+        ),
         "_start_at": to_datetime(start_date),
         "_end_at": to_datetime(end_date + timedelta(days=1)),
-        "_period": "week",
+        "_period": period,
         "dataType": data_type
     }
     dimensions = item.get("dimensions", {}).items()

--- a/tests/backdrop/collector/test_ga.py
+++ b/tests/backdrop/collector/test_ga.py
@@ -30,9 +30,10 @@ def test_query_ga_with_empty_response():
 
 
 def test_data_id():
-    assert_that(data_id("a", dt(2013, 1, 1, 12, 0, 0, "UTC")), is_("a_20130101120000"))
-    assert_that(data_id("a", dt(2013, 6, 1, 12, 0, 0, "Europe/London")), is_("a_20130601110000"))
-    assert_that(data_id("a", dt(2013, 8, 15, 12, 0, 0, "Europe/Rome")), is_("a_20130815100000"))
+    assert_that(
+        data_id("a", dt(2012, 1, 1, 12, 0, 0, "UTC"), "week", ["one", "two"]),
+        is_("YV8yMDEyMDEwMTEyMDAwMF93ZWVrX29uZV90d28=")
+    )
 
 
 def test_build_document():
@@ -44,7 +45,7 @@ def test_build_document():
     data = build_document(gapy_response, "weeklyvisits", date(2013, 4, 1), date(2013, 4, 7))
 
     assert_that(data, has_entry("_id",
-                                "weeklyvisits_20130331230000"))
+                                "d2Vla2x5dmlzaXRzXzIwMTMwMzMxMjMwMDAwX3dlZWtfMjAxMy0wNC0wMg=="))
     assert_that(data, has_entry("dataType", "weeklyvisits"))
     assert_that(data, has_entry("_start_at",
                                 dt(2013, 4, 1, 0, 0, 0, "Europe/London")))
@@ -60,7 +61,9 @@ def test_build_document_no_dimensions():
         "metrics": {"visits": "12345", "visitors": "5376"}
     }
 
-    data = build_document(gapy_response, None, date(2013, 4, 1),
+    data = build_document(gapy_response,
+                          "foo",
+                          date(2013, 4, 1),
                           date(2013, 4, 7))
 
     assert_that(data, has_entry("_start_at",
@@ -70,3 +73,7 @@ def test_build_document_no_dimensions():
     assert_that(data, has_entry("_period", "week"))
     assert_that(data, has_entry("visits", 12345))
     assert_that(data, has_entry("visitors", 5376))
+
+@raises(ValueError)
+def test_build_document_fails_with_no_data_type():
+    build_document({}, None, date(2012, 12, 12), date(2012, 12, 13))


### PR DESCRIPTION
Without these the id is not unique. Base64 encoding the id to allow any
dimension values.

@maxfliri
@robyoung
