### PR TITLE
Bump gapy to 0.0.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gapy==0.0.5
+gapy==0.0.6
 python-dateutil==2.1
 pytz==2013b
 requests


### PR DESCRIPTION
Failed when no rows are returned.
