### PR TITLE
Use https for git instead of git protocol

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ gapy==0.0.8
 python-dateutil==2.1
 pytz==2013d
 requests==1.2.3
--e git+git://github.com/alphagov/backdrop-collector.git@0.0.5#egg=backdrop-collector
+-e git+https://github.com/alphagov/backdrop-collector.git@0.0.5#egg=backdrop-collector


### PR DESCRIPTION
git protocol port is not open on the new performance platform
infrastructure.
