### PR TITLE
Multi value fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ A config is made up of four parts; the data type, the query, mappings and the ta
     },
     "mappings": {
         "customVarValue1": "slug",
-        "customVarValue2": "department"
+        "customVarValue2": "department",
+        "eventCategory_0": "categoryId",
+        "eventCategory_1": "categoryLabel"
     },
     "target": {
         "url": "http://write.backdrop.dev.gov.uk/foo",
@@ -62,6 +64,8 @@ A Google Analytics query.
 ### Mappings (`mappings`)
 
 Allows fields in the google analytics response to be mapped to other fields in the backdrop record.
+
+If a multi value field mapping is specified, the field will be split by the delimiter `:` and mapped accordingly. Example: given the field `key` has the value `foo:bar`, the mapping `key_0` will have the value of `foo` and `key_1` will have the value of `bar`.
 
 ### Target (`target`)
 

--- a/collector/ga.py
+++ b/collector/ga.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import logging
+import re
 
 from requests.exceptions import HTTPError
 from dateutil import parser
@@ -75,9 +76,18 @@ def data_id(data_type, timestamp, period, dimension_values):
 
 
 def apply_key_mapping(mapping, pairs):
-    return dict(
-        [ (mapping.get(key, key), value) for key, value in pairs.items()]
+    mapped_values = dict(
+        [(mapping.get(key, key), value) for key, value in pairs.items()]
     )
+    for from_key, to_key in mapping.items():
+        matches = re.search('(.*)_(\d)', from_key)
+        if matches:
+            key = matches.group(1)
+            index = int(matches.group(2)) - 1
+            value = pairs[key]
+            mapped_values[to_key] = value.split(':')[index]
+
+    return mapped_values
 
 
 def build_document(item, data_type, start_date, mappings=None):

--- a/collector/ga.py
+++ b/collector/ga.py
@@ -75,9 +75,16 @@ def data_id(data_type, timestamp, period, dimension_values):
     ))
 
 
+def map_fields_one_to_one(mapping, pairs):
+    return dict(
+        [(mapping.get(key, key), value) for key, value in pairs.items()]
+    )
+
+
 def apply_multi_value_fields_mapping(mapping, pairs):
     multi_value_regexp = '(.*)_(\d)'
     multi_value_delimiter = ':'
+    mapped_pairs = {}
 
     for from_key, to_key in mapping.items():
         multi_value_matches = re.search(multi_value_regexp, from_key)
@@ -90,16 +97,14 @@ def apply_multi_value_fields_mapping(mapping, pairs):
 
             values = multi_value.split(multi_value_delimiter)
             if index < len(values):
-                pairs[to_key] = values[index]
+                mapped_pairs[to_key] = values[index]
 
-    return pairs
+    return mapped_pairs
 
 
 def apply_key_mapping(mapping, pairs):
-    mapped_pairs = dict(
-        [(mapping.get(key, key), value) for key, value in pairs.items()]
-    )
-    return apply_multi_value_fields_mapping(mapping, mapped_pairs)
+    return dict(map_fields_one_to_one(mapping, pairs).items() +
+                apply_multi_value_fields_mapping(mapping, pairs).items())
 
 
 def build_document(item, data_type, start_date, mappings=None):

--- a/collector/ga.py
+++ b/collector/ga.py
@@ -75,13 +75,13 @@ def data_id(data_type, timestamp, period, dimension_values):
     ))
 
 
-def map_fields_one_to_one(mapping, pairs):
+def map_one_to_one_fields(mapping, pairs):
     return dict(
         [(mapping.get(key, key), value) for key, value in pairs.items()]
     )
 
 
-def apply_multi_value_fields_mapping(mapping, pairs):
+def map_multi_value_fields(mapping, pairs):
     multi_value_regexp = '(.*)_(\d)'
     multi_value_delimiter = ':'
     mapped_pairs = {}
@@ -103,8 +103,8 @@ def apply_multi_value_fields_mapping(mapping, pairs):
 
 
 def apply_key_mapping(mapping, pairs):
-    return dict(map_fields_one_to_one(mapping, pairs).items() +
-                apply_multi_value_fields_mapping(mapping, pairs).items())
+    return dict(map_one_to_one_fields(mapping, pairs).items() +
+                map_multi_value_fields(mapping, pairs).items())
 
 
 def build_document(item, data_type, start_date, mappings=None):

--- a/collector/ga.py
+++ b/collector/ga.py
@@ -82,7 +82,7 @@ def map_one_to_one_fields(mapping, pairs):
 
 
 def map_multi_value_fields(mapping, pairs):
-    multi_value_regexp = '(.*)_(\d)'
+    multi_value_regexp = '^(.*)_(\d*)$'
     multi_value_delimiter = ':'
     mapped_pairs = {}
 

--- a/collector/ga.py
+++ b/collector/ga.py
@@ -80,11 +80,18 @@ def apply_multi_value_fields_mapping(mapping, pairs):
     multi_value_delimiter = ':'
 
     for from_key, to_key in mapping.items():
-        multi_value_mapping = re.search(multi_value_regexp, from_key)
-        if multi_value_mapping:
-            key, index = multi_value_mapping.groups()
-            value = pairs[key]
-            pairs[to_key] = value.split(multi_value_delimiter)[int(index)]
+        multi_value_matches = re.search(multi_value_regexp, from_key)
+        if multi_value_matches:
+            key = multi_value_matches.group(1)
+            index = int(multi_value_matches.group(2))
+            multi_value = pairs.get(key)
+            if multi_value is None:
+                continue
+
+            values = multi_value.split(multi_value_delimiter)
+            if index < len(values):
+                pairs[to_key] = values[index]
+
     return pairs
 
 

--- a/collector/ga.py
+++ b/collector/ga.py
@@ -80,12 +80,11 @@ def apply_key_mapping(mapping, pairs):
         [(mapping.get(key, key), value) for key, value in pairs.items()]
     )
     for from_key, to_key in mapping.items():
-        matches = re.search('(.*)_(\d)', from_key)
-        if matches:
-            key = matches.group(1)
-            index = int(matches.group(2)) - 1
+        multi_value_mapping = re.search('(.*)_(\d)', from_key)
+        if multi_value_mapping:
+            key, index = multi_value_mapping.groups()
             value = pairs[key]
-            mapped_values[to_key] = value.split(':')[index]
+            mapped_values[to_key] = value.split(':')[int(index)]
 
     return mapped_values
 

--- a/collector/ga.py
+++ b/collector/ga.py
@@ -75,18 +75,21 @@ def data_id(data_type, timestamp, period, dimension_values):
     ))
 
 
-def apply_key_mapping(mapping, pairs):
-    mapped_values = dict(
-        [(mapping.get(key, key), value) for key, value in pairs.items()]
-    )
+def apply_multi_value_fields_mapping(mapping, pairs):
     for from_key, to_key in mapping.items():
         multi_value_mapping = re.search('(.*)_(\d)', from_key)
         if multi_value_mapping:
             key, index = multi_value_mapping.groups()
             value = pairs[key]
-            mapped_values[to_key] = value.split(':')[int(index)]
+            pairs[to_key] = value.split(':')[int(index)]
+    return pairs
 
-    return mapped_values
+
+def apply_key_mapping(mapping, pairs):
+    mapped_pairs = dict(
+        [(mapping.get(key, key), value) for key, value in pairs.items()]
+    )
+    return apply_multi_value_fields_mapping(mapping, mapped_pairs)
 
 
 def build_document(item, data_type, start_date, mappings=None):

--- a/collector/ga.py
+++ b/collector/ga.py
@@ -76,12 +76,15 @@ def data_id(data_type, timestamp, period, dimension_values):
 
 
 def apply_multi_value_fields_mapping(mapping, pairs):
+    multi_value_regexp = '(.*)_(\d)'
+    multi_value_delimiter = ':'
+
     for from_key, to_key in mapping.items():
-        multi_value_mapping = re.search('(.*)_(\d)', from_key)
+        multi_value_mapping = re.search(multi_value_regexp, from_key)
         if multi_value_mapping:
             key, index = multi_value_mapping.groups()
             value = pairs[key]
-            pairs[to_key] = value.split(':')[int(index)]
+            pairs[to_key] = value.split(multi_value_delimiter)[int(index)]
     return pairs
 
 

--- a/tests/collector/test_ga.py
+++ b/tests/collector/test_ga.py
@@ -2,7 +2,7 @@ from datetime import date
 from hamcrest import assert_that, is_, has_entries, has_item, equal_to
 import mock
 from nose.tools import *
-from collector.ga import query_ga, build_document, data_id, apply_key_mapping, build_document_set, query_for_range
+from collector.ga import query_ga, build_document, data_id, apply_key_mapping, build_document_set, query_for_range, apply_multi_value_fields_mapping
 from tests.collector import dt
 
 
@@ -163,6 +163,19 @@ def test_apply_key_mapping():
     document = apply_key_mapping(mapping, {"a": "foo", "c": "bar"})
 
     assert_that(document, is_({"b": "foo", "c": "bar"}))
+
+
+def test_map_available_multi_value_fields():
+    mapping = {
+        'key_0': 'one',
+        'key_1': 'two',
+        'key_2': 'not_in_value',
+        'no_key_0': 'dont_exist'
+    }
+
+    document = apply_multi_value_fields_mapping(mapping, {'key': 'foo:bar'})
+
+    assert_that(document, is_({'key': 'foo:bar', 'one': 'foo', 'two': 'bar'}))
 
 
 def test_build_document_set():

--- a/tests/collector/test_ga.py
+++ b/tests/collector/test_ga.py
@@ -137,6 +137,7 @@ def test_build_document_mappings_are_applied_to_dimensions():
 
 def test_build_document_with_multi_value_field_mappings():
     mappings = {
+        "multiValuesField": "originalField",
         "multiValuesField_0": "first",
         "multiValuesField_1": "second",
         "multiValuesField_2": "third",
@@ -150,7 +151,7 @@ def test_build_document_with_multi_value_field_mappings():
     doc = build_document(gapy_response, "multival", date(2013, 4, 1), mappings)
 
     assert_that(doc, has_entries({
-        "multiValuesField": "first value:second value:third value",
+        "originalField": "first value:second value:third value",
         "first": "first value",
         "second": "second value",
         "third": "third value",
@@ -175,7 +176,7 @@ def test_map_available_multi_value_fields():
 
     document = apply_multi_value_fields_mapping(mapping, {'key': 'foo:bar'})
 
-    assert_that(document, is_({'key': 'foo:bar', 'one': 'foo', 'two': 'bar'}))
+    assert_that(document, is_({'one': 'foo', 'two': 'bar'}))
 
 
 def test_build_document_set():

--- a/tests/collector/test_ga.py
+++ b/tests/collector/test_ga.py
@@ -135,6 +135,19 @@ def test_build_document_mappings_are_applied_to_dimensions():
     }))
 
 
+def test_build_document_with_colon_values():
+    gapy_response = {
+        "metrics": {"visits": "12345"},
+        "dimensions": {"multiValuesField": "first value:second value:third value"}
+    }
+
+    doc = build_document(gapy_response, "multival", date(2013, 4, 1), None)
+
+    assert_that(doc, has_entries({
+        "multiValuesField": "first value:second value:third value"
+    }))
+
+
 def test_apply_key_mapping():
     mapping = {"a": "b"}
 

--- a/tests/collector/test_ga.py
+++ b/tests/collector/test_ga.py
@@ -2,7 +2,7 @@ from datetime import date
 from hamcrest import assert_that, is_, has_entries, has_item, equal_to
 import mock
 from nose.tools import *
-from collector.ga import query_ga, build_document, data_id, apply_key_mapping, build_document_set, query_for_range, apply_multi_value_fields_mapping
+from collector.ga import query_ga, build_document, data_id, apply_key_mapping, build_document_set, query_for_range, map_multi_value_fields
 from tests.collector import dt
 
 
@@ -174,7 +174,7 @@ def test_map_available_multi_value_fields():
         'no_key_0': 'dont_exist'
     }
 
-    document = apply_multi_value_fields_mapping(mapping, {'key': 'foo:bar'})
+    document = map_multi_value_fields(mapping, {'key': 'foo:bar'})
 
     assert_that(document, is_({'one': 'foo', 'two': 'bar'}))
 

--- a/tests/collector/test_ga.py
+++ b/tests/collector/test_ga.py
@@ -135,16 +135,25 @@ def test_build_document_mappings_are_applied_to_dimensions():
     }))
 
 
-def test_build_document_with_colon_values():
+def test_build_document_with_multi_value_field_mappings():
+    mappings = {
+        "multiValuesField_1": "first",
+        "multiValuesField_2": "second",
+        "multiValuesField_3": "third",
+    }
+
     gapy_response = {
         "metrics": {"visits": "12345"},
         "dimensions": {"multiValuesField": "first value:second value:third value"}
     }
 
-    doc = build_document(gapy_response, "multival", date(2013, 4, 1), None)
+    doc = build_document(gapy_response, "multival", date(2013, 4, 1), mappings)
 
     assert_that(doc, has_entries({
-        "multiValuesField": "first value:second value:third value"
+        "multiValuesField": "first value:second value:third value",
+        "first": "first value",
+        "second": "second value",
+        "third": "third value",
     }))
 
 

--- a/tests/collector/test_ga.py
+++ b/tests/collector/test_ga.py
@@ -168,6 +168,7 @@ def test_apply_key_mapping():
 
 def test_map_available_multi_value_fields():
     mapping = {
+        'key_0_not_really': 'no_a_multi_key',
         'key_0': 'one',
         'key_1': 'two',
         'key_2': 'not_in_value',

--- a/tests/collector/test_ga.py
+++ b/tests/collector/test_ga.py
@@ -137,9 +137,9 @@ def test_build_document_mappings_are_applied_to_dimensions():
 
 def test_build_document_with_multi_value_field_mappings():
     mappings = {
-        "multiValuesField_1": "first",
-        "multiValuesField_2": "second",
-        "multiValuesField_3": "third",
+        "multiValuesField_0": "first",
+        "multiValuesField_1": "second",
+        "multiValuesField_2": "third",
     }
 
     gapy_response = {


### PR DESCRIPTION
If a multi value field mapping is specified, the field will be split by the delimiter `:` and mapped accordingly. Example: given the field `key` has the value `foo:bar`, the mapping `key_0` will have the value of `foo` and `key_1` will have the value of `bar`.
