### PR TITLE
Treat times as UTC

### DIFF
--- a/collector/datetimeutil.py
+++ b/collector/datetimeutil.py
@@ -2,13 +2,11 @@ from datetime import datetime, time, timedelta, date
 import pytz
 
 
-GB_TIMEZONE = pytz.timezone("Europe/London")
-
 MONDAY = 0
 
 
 def to_datetime(a_date):
-    return GB_TIMEZONE.localize(datetime.combine(a_date, time(0)))
+    return datetime.combine(a_date, time(0)).replace(tzinfo=pytz.UTC)
 
 
 def to_utc(a_datetime):

--- a/collector/ga.py
+++ b/collector/ga.py
@@ -69,10 +69,9 @@ def _format(timestamp):
     return to_utc(timestamp).strftime("%Y%m%d%H%M%S")
 
 
-def data_id(data_type, timestamp, period, dimension_values):
+def data_id(data_type, timestamp, period):
     return base64.urlsafe_b64encode("_".join(
-        [data_type, _format(timestamp), period] + dimension_values
-    ))
+        [data_type, _format(timestamp), period]))
 
 
 def map_one_to_one_fields(mapping, pairs):
@@ -115,9 +114,7 @@ def build_document(item, data_type, start_date, mappings=None):
     period = "week"
     base_properties = {
         "_id": data_id(
-            data_type, to_datetime(start_date), period,
-            item.get("dimensions", {}).values()
-        ),
+            data_type, to_datetime(start_date), period),
         "_timestamp": to_datetime(start_date),
         "timeSpan": period,
         "dataType": data_type

--- a/tests/collector/test_ga.py
+++ b/tests/collector/test_ga.py
@@ -98,8 +98,8 @@ def test_query_for_range():
 
 def test_data_id():
     assert_that(
-        data_id("a", dt(2012, 1, 1, 12, 0, 0, "UTC"), "week", ["one", "two"]),
-        is_("YV8yMDEyMDEwMTEyMDAwMF93ZWVrX29uZV90d28=")
+        data_id("a", dt(2012, 1, 1, 12, 0, 0, "UTC"), "week"),
+        is_("YV8yMDEyMDEwMTEyMDAwMF93ZWVr")
     )
 
 
@@ -112,9 +112,9 @@ def test_build_document():
     data = build_document(gapy_response, "weeklyvisits", date(2013, 4, 1))
 
     assert_that(data, has_entries({
-        "_id": "d2Vla2x5dmlzaXRzXzIwMTMwMzMxMjMwMDAwX3dlZWtfMjAxMy0wNC0wMg==",
+        "_id": "d2Vla2x5dmlzaXRzXzIwMTMwNDAxMDAwMDAwX3dlZWs=",
         "dataType": "weeklyvisits",
-        "_timestamp": dt(2013, 4, 1, 0, 0, 0, "Europe/London"),
+        "_timestamp": dt(2013, 4, 1, 0, 0, 0, "UTC"),
         "timeSpan": "week",
         "date": "2013-04-02",
         "visits": 12345,
@@ -129,7 +129,7 @@ def test_build_document_no_dimensions():
     data = build_document(gapy_response, "foo", date(2013, 4, 1))
 
     assert_that(data, has_entries({
-        "_timestamp": dt(2013, 4, 1, 0, 0, 0, "Europe/London"),
+        "_timestamp": dt(2013, 4, 1, 0, 0, 0, "UTC"),
         "timeSpan": "week",
         "visits": 12345,
         "visitors": 5376,
@@ -216,18 +216,18 @@ def test_build_document_set():
 
     assert_that(docs, has_item(has_entries({
         "name": "Jane",
-        "_timestamp": dt(2013, 4, 1, 0, 0, 0, "Europe/London"),
+        "_timestamp": dt(2013, 4, 1, 0, 0, 0, "UTC"),
         "dataType": "people",
         "visits": 12345,
     })))
     assert_that(docs, has_item(has_entries({
         "name": "John",
-        "_timestamp": dt(2013, 4, 1, 0, 0, 0, "Europe/London"),
+        "_timestamp": dt(2013, 4, 1, 0, 0, 0, "UTC"),
         "visits": 2313,
     })))
     assert_that(docs, has_item(has_entries({
         "name": "Joanne",
-        "_timestamp": dt(2013, 4, 8, 0, 0, 0, "Europe/London"),
+        "_timestamp": dt(2013, 4, 8, 0, 0, 0, "UTC"),
         "visits": 4323,
     })))
 


### PR DESCRIPTION
This is not actually accurate but it makes live a lot simpler down the
line.

See https://www.pivotaltracker.com/story/show/62779118 for details.

This commit also changes the `data_id` function to not include the
dimension values as part of the id. This is because they are not passed
through to backdrop and therefore can't be used to rebuild the id at a
later stage if needed. Also, records are never identified by their
dimension values within a single bucked (they would be in separate
buckets).

Coupled with https://github.com/alphagov/backdrop/pull/220
