### PR TITLE
Switching to latest version of backdrop-collector

### DIFF
--- a/collect.py
+++ b/collect.py
@@ -1,11 +1,13 @@
 import logging
+import os
 
 from backdrop.collector import arguments
 from backdrop.collector.logging_setup import set_up_logging
 from collector.ga import send_records_for
 
 if __name__ == '__main__':
-    set_up_logging('ga_collector', logging.DEBUG)
+    logfile_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'log')
+    set_up_logging('ga_collector', logging.DEBUG, logfile_path)
 
     args = arguments.parse_args('Google Analytics')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ gapy==0.0.8
 python-dateutil==2.1
 pytz==2013d
 requests==1.2.3
--e git+https://github.com/alphagov/backdrop-collector.git@0.0.6#egg=backdrop-collector
+-e git+https://github.com/alphagov/backdrop-collector.git@0.0.8#egg=backdrop-collector


### PR DESCRIPTION
The latest version of backdrop-collector has an extra parameter in set_up_logging() which allows one to specify the logfile_path. Previously logfiles were being created in a place relative to cron's working directory.
