### PR TITLE
Coerce start and end dates to date objects

### DIFF
--- a/collector/datetimeutil.py
+++ b/collector/datetimeutil.py
@@ -9,13 +9,24 @@ def to_datetime(a_date):
     return datetime.combine(a_date, time(0)).replace(tzinfo=pytz.UTC)
 
 
+def to_date(a_datetime):
+    if a_datetime is None:
+        return None
+    elif isinstance(a_datetime, datetime):
+        return a_datetime.date()
+    elif isinstance(a_datetime, date):
+        return a_datetime
+    else:
+        raise ValueError
+
+
 def to_utc(a_datetime):
     return a_datetime.astimezone(pytz.UTC)
 
 
 def period_range(start_date, end_date):
-    start_date = start_date or a_week_ago()
-    end_date = end_date or a_week_ago()
+    start_date = to_date(start_date) or a_week_ago()
+    end_date = to_date(end_date) or a_week_ago()
 
     if start_date > end_date:
         raise ValueError

--- a/tests/collector/test_datetimeutil.py
+++ b/tests/collector/test_datetimeutil.py
@@ -1,12 +1,32 @@
-from datetime import date
-from hamcrest import assert_that, only_contains
+from datetime import date, datetime
+from hamcrest import assert_that, only_contains, is_, equal_to
 from nose.tools import raises
 from freezegun import freeze_time
-from collector.datetimeutil import period_range
+from collector.datetimeutil import period_range, to_date
+
+
+def test_to_date_passes_none_through():
+    assert_that(to_date(None), is_(None))
+
+
+def test_to_date_converts_datetime_to_date():
+    assert_that(
+        to_date(datetime(2012, 12, 12)),
+        equal_to(date(2012, 12, 12)))
+
+
+def test_to_date_passes_date_through():
+    assert_that(
+        to_date(date(2012, 12, 12)),
+        equal_to(date(2012, 12, 12)))
+
+
+@raises(ValueError)
+def test_to_date_raises_error_on_invalid_input():
+    to_date("")
 
 
 def test_period_range():
-
     range = period_range(date(2013, 4, 1), date(2013, 4, 7))
     assert_that(range, only_contains(
         (date(2013, 4, 1), date(2013, 4, 7))
@@ -17,6 +37,13 @@ def test_period_range():
         (date(2013, 4, 1), date(2013, 4, 7)),
         (date(2013, 4, 8), date(2013, 4, 14)),
         (date(2013, 4, 15), date(2013, 4, 21)),
+    ))
+
+
+def test_period_range_between_datetime_and_date():
+    range = period_range(datetime(2013, 4, 1), date(2013, 4, 7))
+    assert_that(range, only_contains(
+        (date(2013, 4, 1), date(2013, 4, 7))
     ))
 
 


### PR DESCRIPTION
They can be datetime objects but datetime objects cannot be compared to
date objects.
