### PR TITLE
Reinstate dimensions in the _id field

### DIFF
--- a/collector/ga.py
+++ b/collector/ga.py
@@ -66,9 +66,9 @@ def _format(timestamp):
     return to_utc(timestamp).strftime("%Y%m%d%H%M%S")
 
 
-def data_id(data_type, timestamp, period):
+def data_id(data_type, timestamp, period, dimension_values):
     return base64.urlsafe_b64encode("_".join(
-        [data_type, _format(timestamp), period]))
+        [data_type, _format(timestamp), period] + dimension_values))
 
 
 def map_one_to_one_fields(mapping, pairs):
@@ -111,7 +111,8 @@ def build_document(item, data_type, start_date, mappings=None):
     period = "week"
     base_properties = {
         "_id": data_id(
-            data_type, to_datetime(start_date), period),
+            data_type, to_datetime(start_date), period,
+            item.get('dimensions', {}).values()),
         "_timestamp": to_datetime(start_date),
         "timeSpan": period,
         "dataType": data_type

--- a/collector/ga.py
+++ b/collector/ga.py
@@ -67,8 +67,8 @@ def _format(timestamp):
 
 
 def data_id(data_type, timestamp, period, dimension_values):
-    return base64.urlsafe_b64encode("_".join(
-        [data_type, _format(timestamp), period] + dimension_values))
+    return "_".join(
+        [data_type, _format(timestamp), period] + dimension_values)
 
 
 def map_one_to_one_fields(mapping, pairs):

--- a/tests/collector/test_ga.py
+++ b/tests/collector/test_ga.py
@@ -99,7 +99,7 @@ def test_query_for_range():
 def test_data_id():
     assert_that(
         data_id("a", dt(2012, 1, 1, 12, 0, 0, "UTC"), "week", ['one', 'two']),
-        is_("YV8yMDEyMDEwMTEyMDAwMF93ZWVrX29uZV90d28=")
+        is_('a_20120101120000_week_one_two')
     )
 
 
@@ -112,7 +112,7 @@ def test_build_document():
     data = build_document(gapy_response, "weeklyvisits", date(2013, 4, 1))
 
     assert_that(data, has_entries({
-        "_id": "d2Vla2x5dmlzaXRzXzIwMTMwNDAxMDAwMDAwX3dlZWtfMjAxMy0wNC0wMg==",
+        "_id": "weeklyvisits_20130401000000_week_2013-04-02",
         "dataType": "weeklyvisits",
         "_timestamp": dt(2013, 4, 1, 0, 0, 0, "UTC"),
         "timeSpan": "week",

--- a/tests/collector/test_ga.py
+++ b/tests/collector/test_ga.py
@@ -98,8 +98,8 @@ def test_query_for_range():
 
 def test_data_id():
     assert_that(
-        data_id("a", dt(2012, 1, 1, 12, 0, 0, "UTC"), "week"),
-        is_("YV8yMDEyMDEwMTEyMDAwMF93ZWVr")
+        data_id("a", dt(2012, 1, 1, 12, 0, 0, "UTC"), "week", ['one', 'two']),
+        is_("YV8yMDEyMDEwMTEyMDAwMF93ZWVrX29uZV90d28=")
     )
 
 
@@ -112,7 +112,7 @@ def test_build_document():
     data = build_document(gapy_response, "weeklyvisits", date(2013, 4, 1))
 
     assert_that(data, has_entries({
-        "_id": "d2Vla2x5dmlzaXRzXzIwMTMwNDAxMDAwMDAwX3dlZWs=",
+        "_id": "d2Vla2x5dmlzaXRzXzIwMTMwNDAxMDAwMDAwX3dlZWtfMjAxMy0wNC0wMg==",
         "dataType": "weeklyvisits",
         "_timestamp": dt(2013, 4, 1, 0, 0, 0, "UTC"),
         "timeSpan": "week",


### PR DESCRIPTION
Because they are a unique part of the record. Removing it in previous
commit 7cf43e52f17c709d2c4035537b2f2bbb16de5143 caused a regression:
https://www.pivotaltracker.com/story/show/63703882

Note that I'm planning on making the `_id` field human-readable, instead of base64 encoded, but in the interests of getting this bug fixed ASAP I'll do that in a separate pull request.
