### PR TITLE
Base64 encode the _id

### DIFF
--- a/collector/ga.py
+++ b/collector/ga.py
@@ -67,8 +67,9 @@ def _format(timestamp):
 
 
 def data_id(data_type, timestamp, period, dimension_values):
-    return base64.urlsafe_b64encode("_".join(
-        [data_type, _format(timestamp), period] + dimension_values))
+    human_id = "_".join(
+        [data_type, _format(timestamp), period] + dimension_values)
+    return base64.urlsafe_b64encode(human_id), human_id
 
 
 def map_one_to_one_fields(mapping, pairs):
@@ -109,11 +110,17 @@ def build_document(item, data_type, start_date, mappings=None):
     if mappings is None:
         mappings = {}
     period = "week"
+
+    (_id, human_id) = data_id(
+        data_type,
+        to_datetime(start_date),
+        period,
+        item.get('dimensions', {}).values())
+
     base_properties = {
-        "_id": data_id(
-            data_type, to_datetime(start_date), period,
-            item.get('dimensions', {}).values()),
+        "_id": _id,
         "_timestamp": to_datetime(start_date),
+        "humanId": human_id,
         "timeSpan": period,
         "dataType": data_type
     }

--- a/collector/ga.py
+++ b/collector/ga.py
@@ -67,8 +67,8 @@ def _format(timestamp):
 
 
 def data_id(data_type, timestamp, period, dimension_values):
-    return "_".join(
-        [data_type, _format(timestamp), period] + dimension_values)
+    return base64.urlsafe_b64encode("_".join(
+        [data_type, _format(timestamp), period] + dimension_values))
 
 
 def map_one_to_one_fields(mapping, pairs):

--- a/tests/collector/test_ga.py
+++ b/tests/collector/test_ga.py
@@ -99,7 +99,10 @@ def test_query_for_range():
 def test_data_id():
     assert_that(
         data_id("a", dt(2012, 1, 1, 12, 0, 0, "UTC"), "week", ['one', 'two']),
-        is_("YV8yMDEyMDEwMTEyMDAwMF93ZWVrX29uZV90d28=")
+        is_(
+            ("YV8yMDEyMDEwMTEyMDAwMF93ZWVrX29uZV90d28=",
+             "a_20120101120000_week_one_two")
+        )
     )
 
 
@@ -113,6 +116,7 @@ def test_build_document():
 
     assert_that(data, has_entries({
         "_id": "d2Vla2x5dmlzaXRzXzIwMTMwNDAxMDAwMDAwX3dlZWtfMjAxMy0wNC0wMg==",
+        "humanId": 'weeklyvisits_20130401000000_week_2013-04-02',
         "dataType": "weeklyvisits",
         "_timestamp": dt(2013, 4, 1, 0, 0, 0, "UTC"),
         "timeSpan": "week",

--- a/tests/collector/test_ga.py
+++ b/tests/collector/test_ga.py
@@ -99,7 +99,7 @@ def test_query_for_range():
 def test_data_id():
     assert_that(
         data_id("a", dt(2012, 1, 1, 12, 0, 0, "UTC"), "week", ['one', 'two']),
-        is_('a_20120101120000_week_one_two')
+        is_("YV8yMDEyMDEwMTEyMDAwMF93ZWVrX29uZV90d28=")
     )
 
 
@@ -112,7 +112,7 @@ def test_build_document():
     data = build_document(gapy_response, "weeklyvisits", date(2013, 4, 1))
 
     assert_that(data, has_entries({
-        "_id": "weeklyvisits_20130401000000_week_2013-04-02",
+        "_id": "d2Vla2x5dmlzaXRzXzIwMTMwNDAxMDAwMDAwX3dlZWtfMjAxMy0wNC0wMg==",
         "dataType": "weeklyvisits",
         "_timestamp": dt(2013, 4, 1, 0, 0, 0, "UTC"),
         "timeSpan": "week",


### PR DESCRIPTION
Revert the previous change to make _ids human readable. This is not OK because of things like User Agents which have spaces in.

As a happy compromise, we're baes64 encoding the _id but also including a `humanId` field to aid debugging of data in buckets. 

See https://www.pivotaltracker.com/story/show/63703882
