### PR TITLE
Before base64 encoding the _id, UTF-8 encode it

### DIFF
--- a/collector/ga.py
+++ b/collector/ga.py
@@ -69,7 +69,9 @@ def _format(timestamp):
 def data_id(data_type, timestamp, period, dimension_values):
     human_id = "_".join(
         [data_type, _format(timestamp), period] + dimension_values)
-    return base64.urlsafe_b64encode(human_id), human_id
+    human_id_bytes = human_id.encode('utf-8')
+    logging.debug(u"'{}' ({})".format(human_id, type(human_id)))
+    return base64.urlsafe_b64encode(human_id_bytes), human_id_bytes
 
 
 def map_one_to_one_fields(mapping, pairs):

--- a/collector/ga.py
+++ b/collector/ga.py
@@ -70,7 +70,7 @@ def data_id(data_type, timestamp, period, dimension_values):
     human_id = "_".join(
         [data_type, _format(timestamp), period] + dimension_values)
     human_id_bytes = human_id.encode('utf-8')
-    logging.debug(u"'{}' ({})".format(human_id, type(human_id)))
+    logging.debug(u"'{0}' ({1})".format(human_id, type(human_id)))
     return base64.urlsafe_b64encode(human_id_bytes), human_id_bytes
 
 

--- a/tests/collector/test_ga.py
+++ b/tests/collector/test_ga.py
@@ -1,7 +1,10 @@
+# encoding: utf-8
+
 from datetime import date
 from hamcrest import assert_that, is_, has_entries, has_item, equal_to
 import mock
 from nose.tools import *
+from nose.tools import assert_is_instance
 from collector.ga import query_ga, build_document, data_id, apply_key_mapping, build_document_set, query_for_range, map_multi_value_fields
 from tests.collector import dt
 
@@ -104,6 +107,19 @@ def test_data_id():
              "a_20120101120000_week_one_two")
         )
     )
+
+
+def test_unicode_data_id():
+    base64, human = data_id(
+        "a",
+        dt(2012, 1, 1, 12, 0, 0, "UTC"),
+        "week",
+        ['one', u"© ☯ ☮"])
+
+    assert_is_instance(human, str)
+    assert_that(human, is_(str("a_20120101120000_week_one_© ☯ ☮")))
+    assert_that(base64,
+                is_("YV8yMDEyMDEwMTEyMDAwMF93ZWVrX29uZV_CqSDimK8g4piu"))
 
 
 def test_build_document():


### PR DESCRIPTION
Because we currently bomb out with a Unicode error when we try to base64
encode a unicode class. This encodes the unicode to str using UTF-8
codec.

The new test confirms that we can support non-ascii Unicode characters.

The existing test_data_id shows that the _id does _not_ change for
existing, ascii-only ids. So we don't need to flush the buckets.
