### PR TITLE
Don't fail the build if we fail on Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 python:
   - "2.6"
   - "2.7"
+matrix:
+  allow_failures:
+    - python: "2.6"
 install: "pip install -r requirements_for_tests.txt --use-mirrors"
 script: ./run_tests.sh
 branches:


### PR DESCRIPTION
Copying what we now do in https://github.com/alphagov/backdrop, we still
run the tests on Python 2.6 but they are allowed to fail without failing
the whole build.

The Python 2.7 features which prompted this are `assert_is_instance` from
`nose.tools` and `"{}".format(...)` - the former in particular is a
very useful test method.
