### PR TITLE
Accept id dimension

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ A config is made up of four parts; the data type, the query, mappings and the ta
         "eventCategory_0": "categoryId",
         "eventCategory_1": "categoryLabel"
     },
+    "idDimension": "eventCategory",
     "target": {
         "url": "http://write.backdrop.dev.gov.uk/foo",
         "token": "foo-bearer-token"
@@ -84,6 +85,10 @@ A Google Analytics query.
 Allows fields in the google analytics response to be mapped to other fields in the backdrop record.
 
 If a multi value field mapping is specified, the field will be split by the delimiter `:` and mapped accordingly. Example: given the field `key` has the value `foo:bar`, the mapping `key_0` will have the value of `foo` and `key_1` will have the value of `bar`.
+
+### Dimension as ID (`idDimension`)
+
+Allows you to configure one of the dimensions fields as the ID for the row, rather than the auto generated unique ID.
 
 ### Target (`target`)
 

--- a/collector/ga.py
+++ b/collector/ga.py
@@ -3,13 +3,9 @@ import json
 import logging
 import re
 
-from requests.exceptions import HTTPError
-from dateutil import parser
 from gapy.client import from_private_key, from_secrets_file
-from gapy.error import GapyError
 import requests
 
-from collector import load_json, get_credentials
 from collector.datetimeutil \
     import to_datetime, period_range, to_utc, a_week_ago
 from collector.jsonencoder import JSONEncoder

--- a/collector/ga.py
+++ b/collector/ga.py
@@ -66,12 +66,16 @@ def _format(timestamp):
     return to_utc(timestamp).strftime("%Y%m%d%H%M%S")
 
 
+def value_id(value):
+    value_bytes = value.encode('utf-8')
+    logging.debug(u"'{0}' ({1})".format(value, type(value)))
+    return base64.urlsafe_b64encode(value_bytes), value_bytes
+
+
 def data_id(data_type, timestamp, period, dimension_values):
     human_id = "_".join(
         [data_type, _format(timestamp), period] + dimension_values)
-    human_id_bytes = human_id.encode('utf-8')
-    logging.debug(u"'{0}' ({1})".format(human_id, type(human_id)))
-    return base64.urlsafe_b64encode(human_id_bytes), human_id_bytes
+    return value_id(human_id)
 
 
 def map_one_to_one_fields(mapping, pairs):
@@ -106,18 +110,23 @@ def apply_key_mapping(mapping, pairs):
                 map_multi_value_fields(mapping, pairs).items())
 
 
-def build_document(item, data_type, start_date, mappings=None):
+def build_document(item, data_type, start_date,
+                   mappings=None, idDimension=None):
     if data_type is None:
         raise ValueError("Must provide a data type")
     if mappings is None:
         mappings = {}
     period = "week"
 
-    (_id, human_id) = data_id(
-        data_type,
-        to_datetime(start_date),
-        period,
-        item.get('dimensions', {}).values())
+    if idDimension is not None:
+        (_id, human_id) = value_id(
+            item['dimensions'][idDimension])
+    else:
+        (_id, human_id) = data_id(
+            data_type,
+            to_datetime(start_date),
+            period,
+            item.get('dimensions', {}).values())
 
     base_properties = {
         "_id": _id,
@@ -137,8 +146,8 @@ def pretty_print(obj):
     return json.dumps(obj, indent=2)
 
 
-def build_document_set(results, data_type, mappings):
-    return [build_document(item, data_type, start, mappings)
+def build_document_set(results, data_type, mappings, idDimension=None):
+    return [build_document(item, data_type, start, mappings, idDimension)
             for start, item in results]
 
 
@@ -155,10 +164,12 @@ def query_documents_for(query, credentials, start_date, end_date):
     client = _create_client(credentials)
 
     mappings = query.get("mappings", {})
+    idDimension = query.get("idDimension", None)
 
     results = query_for_range(client, query["query"], start_date, end_date)
 
-    return build_document_set(results, query["dataType"], mappings)
+    return build_document_set(results, query["dataType"],
+                              mappings, idDimension)
 
 
 def send_records_for(query, credentials, start_date=None, end_date=None):

--- a/tests/collector/test_ga.py
+++ b/tests/collector/test_ga.py
@@ -61,7 +61,7 @@ def test_dimensions_are_optional_for_querying():
     }
     client = mock.Mock()
 
-    response = query_ga(client, config, date(2013, 4, 1), date(2013, 4, 7))
+    query_ga(client, config, date(2013, 4, 1), date(2013, 4, 7))
 
     client.query.get.assert_called_once_with(
         "123",
@@ -182,7 +182,9 @@ def test_build_document_with_multi_value_field_mappings():
 
     gapy_response = {
         "metrics": {"visits": "12345"},
-        "dimensions": {"multiValuesField": "first value:second value:third value"}
+        "dimensions": {
+            "multiValuesField": "first value:second value:third value"
+        }
     }
 
     doc = build_document(gapy_response, "multival", date(2013, 4, 1), mappings)

--- a/tests/collector/test_ga.py
+++ b/tests/collector/test_ga.py
@@ -255,3 +255,13 @@ def test_build_document_set():
 @raises(ValueError)
 def test_build_document_fails_with_no_data_type():
     build_document({}, None, date(2012, 12, 12))
+
+
+def test_if_we_provide_id_field_it_is_used():
+    doc = build_document({"dimensions": {"idVar": "foo"},
+                          "metrics": {"some_metric": 123}},
+                         "data_type",
+                         date(2014, 2, 19),
+                         idDimension="idVar")
+
+    eq_(doc["_id"], "Zm9v")


### PR DESCRIPTION
In some situations we want the id of each row to be a known field value,
this is so that we can overwrite existing values with new values.
Dimensions seemed the only reasonable set of fields to pick out of as
deriving an id from the metric you are measuring seemed pointless for
this purpose.

IDs are base64'd such that no characters backdrop doesn't like in IDs
can end up there.
