### PR TITLE
Pull the latest gapy in via git.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-gapy==0.0.8
 python-dateutil==2.1
 pytz==2013d
 requests==1.2.3
+-e git+https://github.com/robyoung/gapy.git@master#egg=gapy
 -e git+https://github.com/alphagov/backdrop-collector.git@0.0.8#egg=backdrop-collector


### PR DESCRIPTION
A bug fix has been pushed into gapy that deals with AND filters. Rob
hasn't been able to release and I can't so we need to switch to a git
dep for the moment.
