### PR TITLE
Cast all values to string before using as an id

### DIFF
--- a/collector/ga.py
+++ b/collector/ga.py
@@ -69,9 +69,10 @@ def value_id(value):
 
 
 def data_id(data_type, timestamp, period, dimension_values):
-    human_id = "_".join(
-        [data_type, _format(timestamp), period] + dimension_values)
-    return value_id(human_id)
+    # `dimension_values` may be non-string python types and need to be coerced.
+    values = map(unicode, dimension_values)
+    slugs = [data_type, _format(timestamp), period] + values
+    return value_id("_".join(slugs))
 
 
 def map_one_to_one_fields(mapping, pairs):


### PR DESCRIPTION
The google analytics API can return values which aren't strings, for example
ga:date comes out of the API as a datetime, which was causing this to exit
with an error in the string join.

I'd appreciate a close review because what I did appears to work
but I'm not sure if it is the right thing to do in all cases
we can imagine, and I'm not very familiar with the code.
