### PR TITLE
Log at level INFO rather than DEBUG

### DIFF
--- a/collect.py
+++ b/collect.py
@@ -8,7 +8,7 @@ from collector.ga import send_records_for
 if __name__ == '__main__':
     logfile_path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), 'log')
-    set_up_logging('ga_collector', logging.DEBUG, logfile_path)
+    set_up_logging('ga_collector', logging.INFO, logfile_path)
 
     args = arguments.parse_args('Google Analytics')
 


### PR DESCRIPTION
Production logs are incredibly noisy with useless logs. This should
ultimately be handled by an environment variable.
