### PR TITLE
Add doc and failing test for additionalFields

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ A config is made up of four parts; the data type, the query, mappings and the ta
       "RemoveKey('customVarValue9')",
       "AggregateKey(aggregate_count('visitors'))"
     ],
+    "additionalFields": {
+        "department": "department-for-fooing-the-bar"
+    },
     "target": {
         "url": "http://write.backdrop.dev.gov.uk/foo",
         "token": "foo-bearer-token"
@@ -106,6 +109,11 @@ The backdrop URL and bearer token that the records will be sent to.
 Plugins are a list of [python expressions](http://docs.python.org/2/reference/expressions.html) (i.e, things that can be the body of a `lambda`) and enable arbitrary transformations to data coming from Google Analytics before it is pushed to backdrop. They are executed in the `backdrop.collector.plugins` namespace.
 
 Plugins reside in the [`backdrop-collector-plugins`](https://github.com/alphagov/backdrop-collector-plugins) repository, and are documented over there.
+
+### Additional fields to set as constant on the document (`additionalFields`)
+
+This can be used to set a value for all documents. Useful if there are multiple
+collectors writing to one bucket.
 
 ## Run the config
 

--- a/collector/ga.py
+++ b/collector/ga.py
@@ -203,6 +203,11 @@ def query_documents_for(client, query, start_date, end_date):
 
     docs = build_document_set(results, query["dataType"], mappings, idMapping)
 
+    if "additionalFields" in query:
+        additional_fields = query["additionalFields"]
+        for doc in docs:
+            doc.update(additional_fields)
+
     if "plugins" in query:
         docs = run_plugins(query["plugins"], docs)
 

--- a/tests/collector/test_ga.py
+++ b/tests/collector/test_ga.py
@@ -403,3 +403,34 @@ def test_query_ga_with_maxresults():
     )
 
     eq_(response, [])
+
+def test_additional_fields():
+
+
+    input_document = {
+        "metrics": {"visits": "12345"},
+        "dimensions": {"date": "2013-04-02", "customVarValue9": "foo"},
+        "start_date": date(2013, 4, 1),
+    }
+
+    client = mock.Mock()
+    client.query.get.return_value = [
+        input_document,
+    ]
+
+    config = {
+        "query": {
+            "id": "ga:123",
+            "metrics": ["visits"],
+            "dimensions": ["date", "customVarValue9"],
+        },
+        "dataType": "test",
+        "additionalFields": {"foo": "bar"},
+    }
+
+    start, end = date(2013, 4, 1), date(2013, 4, 7)
+
+    # Check that without a plugin, we have customVarValue9.
+    result = query_documents_for(client, config, start, end)
+    (output_document,) = result
+    assert_in("foo", result[0])

--- a/tests/collector/test_ga.py
+++ b/tests/collector/test_ga.py
@@ -404,8 +404,8 @@ def test_query_ga_with_maxresults():
 
     eq_(response, [])
 
-def test_additional_fields():
 
+def test_additional_fields():
 
     input_document = {
         "metrics": {"visits": "12345"},


### PR DESCRIPTION
Needed for setting constant values on a document from the configuration.

Will also be used by some contrib collectors to set values on the documents.
