### PR TITLE
Bump backdrop-collector-plugins to version 1.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pytz==2013d
 requests==1.2.3
 gapy==1.1.0
 -e git+https://github.com/alphagov/backdrop-collector.git@2.0.0#egg=backdrop-collector
--e git+https://github.com/alphagov/backdrop-collector-plugins@1.1.0#egg=backdrop-collector-plugins
+-e git+https://github.com/alphagov/backdrop-collector-plugins@1.1.1#egg=backdrop-collector-plugins


### PR DESCRIPTION
Depends on https://github.com/alphagov/backdrop-collector-plugins/pull/14
being merged and tagged.

I'm slightly jumping the gun with this one since the tag doesn't exist yet
(and hence the tests should fail) but I wanted to make it obvious this
is being updated.
