### PR TITLE
Update backdrop-collector-plugins to 1.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pytz==2013d
 requests==1.2.3
 gapy==1.1.0
 -e git+https://github.com/alphagov/backdrop-collector.git@2.0.0#egg=backdrop-collector
--e git+https://github.com/alphagov/backdrop-collector-plugins@1.1.1#egg=backdrop-collector-plugins
+-e git+https://github.com/alphagov/backdrop-collector-plugins@1.1.2#egg=backdrop-collector-plugins


### PR DESCRIPTION
Needed so that UKVI will be populated in the next run.
